### PR TITLE
docs (do not merge yet): replace boilerplate starter README with actual project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,41 @@
-# Cedar-OS + Mastra Starter Template
+# CanDraw
 
-A blank starter template combining [Cedar-OS](https://cedar.ai) for the frontend AI interface and [Mastra](https://mastra.ai) for the backend agent orchestration.
+A voice/chat-driven whiteboard for sketching database schemas. Draw tables and relationships on an Excalidraw canvas, describe changes by voice or chat, and export the diagram to SQL `CREATE TABLE` statements.
 
-## Features
+**Status:** Hackathon project (weekend hackathon, September 2025). Not maintained.
 
-- **Chat Integration**: Built-in chat workflows powered by OpenAI through Mastra agents
-- **Real-time Streaming**: Server-sent events (SSE) for streaming responses
-- **Beautiful UI**: Cedar-OS components with 3D effects and modern design
-- **Type-safe Workflows**: Mastra-based backend with full TypeScript support
-- **Dual API Modes**: Both streaming and non-streaming chat endpoints
+## What it does
 
-## Quick Start
+- Excalidraw-based canvas for drawing tables (rectangles + text) and relationships (arrows that snap to table edges).
+- A chat/voice interface (Cedar-OS on the frontend, Mastra agents on the backend) that can add or modify canvas elements from natural-language instructions.
+- An export step that reads the raw Excalidraw elements, infers tables/fields/relationships via an LLM call, and generates SQL schema output.
 
-The fastest way to get started:
+This started from the Cedar-OS + Mastra Next.js starter template and was built out from there; the starter's chat/streaming scaffolding is still the backend's plumbing, but the schema-drawing, arrow-snapping, and SQL export are what was actually built for the hackathon.
 
-```bash
-npx cedar-os-cli plant-seed
-```
+## Technical notes
 
-Then select this template when prompted. This will set up the entire project structure and dependencies automatically.
+- Arrow-to-table edge snapping is a `useEffect`-driven layer on top of Excalidraw's element model (`src/components/ExcalidrawCanvas.tsx`) since Excalidraw doesn't support that natively.
+- SQL export (`src/backend/src/mastra/tools/llmExportTool.ts`) filters the canvas to rectangle/text/arrow/line elements, then prompts an LLM to parse them into a structured `{tables, relationships, sql}` object rather than parsing shapes geometrically.
+- Voice input worked but the commit history notes occasional infinite loops in the voice workflow; treat it as a rough edge, not a solid feature.
 
-This template contains the Cedar chat connected to a mastra backend to demonstrate what endpoints need to be implemented.
-
-For more details, see the [Cedar Getting Started Guide](https://docs.cedarcopilot.com/getting-started/getting-started).
-
-## Manual Setup
-
-### Prerequisites
-
-- Node.js 18+
-- OpenAI API key
-- pnpm (recommended) or npm
-
-### Installation
-
-1. **Clone and install dependencies:**
+## Usage
 
 ```bash
-git clone <repository-url>
-cd cedar-mastra-starter
 pnpm install && cd src/backend && pnpm install && cd ../..
 ```
 
-2. **Set up environment variables:**
-   Create a `.env` file in the root directory:
-
-```env
-OPENAI_API_KEY=your-openai-api-key-here
-```
-
-3. **Start the development servers:**
+Create `.env` with `OPENAI_API_KEY=...`, then:
 
 ```bash
 npm run dev
 ```
 
-This runs both the Next.js frontend and Mastra backend concurrently:
+Runs the Next.js frontend (`:3000`) and the Mastra backend (`:4111`) together.
 
-- Frontend: http://localhost:3000
-- Backend API: http://localhost:4111
+## Personal contribution
 
-## Project Architecture
-
-### Frontend (Next.js + Cedar-OS)
-
-- **Simple Chat UI**: See Cedar OS components in action in a pre-configured chat interface
-- **Cedar-OS Components**: Cedar-OS Components installed in shadcn style for local changes
-- **Tailwind CSS, Typescript, NextJS**: Patterns you're used to in any NextJS project
-
-### Backend (Mastra)
-
-- **Chat Workflow**: Example of a Mastra workflow – a chained sequence of tasks including LLM calls
-- **Streaming Utils**: Examples of streaming text, status updates, and objects like tool calls
-- **API Routes**: Examples of registering endpoint handlers for interacting with the backend
-
-## API Endpoints (Mastra backend)
-
-### Non-streaming Chat
-
-```bash
-POST /chat/execute-function
-Content-Type: application/json
-
-{
-  "prompt": "Hello, how can you help me?",
-  "temperature": 0.7,
-  "maxTokens": 1000,
-  "systemPrompt": "You are a helpful assistant."
-}
-```
-
-### Streaming Chat
-
-```bash
-POST /chat/execute-function/stream
-Content-Type: application/json
-
-{
-  "prompt": "Tell me a story",
-  "temperature": 0.7
-}
-```
-
-Returns Server-Sent Events with:
-
-- **JSON Objects**: `{ type: 'stage_update', status: 'update_begin', message: 'Generating response...'}`
-- **Text Chunks**: Streamed AI response text
-- **Completion**: `event: done` signal
-
-## Development
-
-### Running the Project
-
-```bash
-# Start both frontend and backend
-npm run dev
-
-# Run frontend only
-npm run dev:next
-
-# Run backend only
-npm run dev:mastra
-```
-
-## Learn More
-
-- [Cedar-OS Documentation](https://docs.cedarcopilot.com/)
-- [Mastra Documentation](https://mastra.ai/docs)
-- [Next.js Documentation](https://nextjs.org/docs)
+Built with a 3-person team over a weekend hackathon. I built the core drawing flow: table rendering, the arrow-snapping logic, and the SQL export/generation path. Teammates worked on the voice integration and chat workflow wiring.
 
 ## License
 
-MIT License - see LICENSE file for details.
+No license file is present, so default copyright applies (all rights reserved) unless you hear otherwise from me directly.


### PR DESCRIPTION
## Summary
- The README was still the untouched Cedar-OS + Mastra starter-template README (described itself as "a blank starter template"). Replaced it with what this project actually is: an Excalidraw-based whiteboard that draws DB schemas by voice/chat and exports them to SQL.
- Added a status line (hackathon project, not maintained), technical notes on the arrow-snapping and SQL-export implementation, and a personal-contribution section.

## Why it matters
A repo whose README says "blank starter template" misrepresents real, working hackathon output (table drawing, arrow snapping, voice input, LLM-driven SQL export) as an unmodified scaffold.

## Docs changed
- README.md only.

## Metadata changed
- Description and topics set via `gh repo edit` (excalidraw, nextjs, cedar-os, mastra, sql, hackathon).

## Validation performed
- Read `src/components/ExcalidrawCanvas.tsx`, `ExportPanel.tsx`, and `src/backend/src/mastra/tools/llmExportTool.ts` to confirm the SQL-export flow and arrow-snapping claims before writing them.
- Checked `git log` for commit messages/dates (weekend hackathon, Sept 26-28 2025) and per-author commit counts to write the contribution section; flagged the "sometimes infinite loops" voice issue directly from a commit message rather than omitting it.
- Confirmed no LICENSE file exists; did not add one (recommend-only per instructions).

## Known uncertainties
- I could not run the app (no OpenAI key available in this environment) to confirm the SQL export still works end-to-end; the description is based on reading the code, not executing it.

## Needs owner confirmation
- Confirm the personal-contribution split (tables/arrows/SQL export by me, voice/chat wiring by teammates) matches your recollection.
- Confirm you're fine with the README candidly noting the voice-loop bug rather than omitting it.

## Security notes
None — docs-only change, no secrets touched or added.